### PR TITLE
Update to net 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.sln
 bin
 obj
+.vs

--- a/MoreLinq.csproj
+++ b/MoreLinq.csproj
@@ -1,13 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <LangVersion>default</LangVersion>
         <RootNamespace>System.Linq</RootNamespace>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0</TargetFrameworks>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Carnagion.MoreLinq</PackageId>
-        <PackageVersion>1.4.0</PackageVersion>
+        <PackageVersion>2.0.0</PackageVersion>
         <Title>MoreLinq</Title>
         <Authors>Carnagion</Authors>
         <Description>A C# library that provides more LINQ extension methods.</Description>

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Almost all extension methods are pure and declarative, keeping to true LINQ and 
 
 # Installation
 
-**MoreLinq** is available as a [NuGet package](https://www.nuget.org/packages/Carnagion.MoreLinq/) for .NET 5.0 and .NET Standard 2.1.
+**MoreLinq** is available as a [NuGet package](https://www.nuget.org/packages/Carnagion.MoreLinq/) for .NET 6.0


### PR DESCRIPTION
The goal of this PR is to get compatibility with the Libaries which are based on godot 4 and therfore on net6.0. Also to make it possible to update Modot with this pr https://github.com/Carnagion/Modot/pull/17.

- [x] Update to net 6.0